### PR TITLE
Make OCSP optional for Sub-CAs

### DIFF
--- a/docs/BR.md
+++ b/docs/BR.md
@@ -1591,7 +1591,10 @@ b. `cRLDistributionPoints`
 
 c. `authorityInformationAccess`
 
-   This extension MUST be present. It MUST NOT be marked critical, and it MUST contain the HTTP URL of the Issuing CA's OCSP responder (`accessMethod` = 1.3.6.1.5.5.7.48.1). It SHOULD also contain the HTTP URL of the Issuing CA's certificate (`accessMethod` = 1.3.6.1.5.5.7.48.2).
+   This extension SHOULD be present. It MUST NOT be marked critical.
+   
+   It SHOULD contain the HTTP URL of the Issuing CA's certificate (`accessMethod` = 1.3.6.1.5.5.7.48.2).
+   It MAY contain the HTTP URL of the Issuing CA's OCSP responder (`accessMethod` = 1.3.6.1.5.5.7.48.1). 
 
 d. `basicConstraints`
 


### PR DESCRIPTION
Historically, Section 7.1.2.2 required CAs MUST support both CRLs and OCSP for Subordinate CA certificates (that is, the Sub-CA certificates themselves). An exception was given for stapling, but that exception largely did not make sense, because support for OCSP Multi-Staple is rare, although TLS 1.3 made that easier.

Existing Root Programs prefer CRLs (Mozilla, Apple, Google) for Sub-CAs, and either make no statement about OCSP, or make it optional so that a CA only needs to support one of either OCSP or CRLs (Microsoft).

As requiring OCSP for a Sub-CA effectively necessitates OCSP delegated signing, due to wanting to avoid having to periodically access root key material, and since OCSP delegated signing is not necessarily desirable, this makes OCSP support a MAY level for Sub-CAs, relying on the existing MUST level provision for CRLs.